### PR TITLE
Refactor Docker setup for Logi webcam support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,6 +141,7 @@ RUN chmod +x /usr/local/bin/ros_docker_auto_startup_launcher.sh
     ros-noetic-audio-common \
     python3-protobuf \
     python3-tk \
+    htop \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get upgrade -y && \
         # --- Utilities ---
         python3-pip python3-pyqt5 alsa-utils portaudio19-dev \
         build-essential git python3-rosdep python3-catkin-tools \
-        python3-matplotlib python3-numpy tmux x11-apps htop \
+        python3-matplotlib python3-numpy tmux x11-apps htop python3-protobuf\
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ---------- Python packages ----------
@@ -34,7 +34,7 @@ RUN pip3 install --default-timeout=100 \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ros-noetic-image-geometry \
-        ros-noetic-rgbd-launch \  # keeps rgbd for completeness; safe to drop if un-needed
+        ros-noetic-rgbd-launch \  
         udev \
         ros-noetic-rosserial-arduino ros-noetic-rosserial-client \
         ros-noetic-rosserial-server ros-noetic-rosserial-python \
@@ -47,7 +47,7 @@ RUN mkdir -p /root/.aws
 COPY certs/aws-credentials /root/.aws/credentials
 COPY certs/aws-config       /root/.aws/config
 RUN chmod 600 /root/.aws/*
-ENV AWS_DEFAULT_REGION=us-east-1     # optional convenience
+ENV AWS_DEFAULT_REGION=us-east-1    
 
 # ---------- Catkin workspace ----------
 ENV CATKIN_WS=/catkin_ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,163 +1,73 @@
-# ------------  base OS & ROS --------------
-# Ubuntu 20.04 + GUI tools + MoveIt
-# official tags: hub.docker.com/_/ros
-
+# ---------- Base OS & ROS ----------
 FROM ros:noetic-ros-core
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install desktop and MoveIt dependencies explicitly to avoid unnecessary packages
+# ---------- Core desktop + MoveIt + common runtime ----------
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-    ros-noetic-desktop \
-    ros-noetic-moveit \
-    ros-noetic-sound-play \
-    # new: hardware & controller support
-    ros-noetic-dynamixel-sdk ros-noetic-dynamixel-sdk-examples \
-    ros-noetic-controller-manager ros-noetic-joint-state-controller \
-    ros-noetic-joint-state-publisher ros-noetic-robot-state-publisher \
-    ros-noetic-gazebo-ros-pkgs \
-    ros-noetic-gazebo-ros-control \
-    ros-noetic-ros-control \
-    ros-noetic-ros-controllers \
-    ros-noetic-rosbag \
-    ros-noetic-smach \
-    ros-noetic-smach-ros \  
-    ros-noetic-smach-viewer \
-    ros-noetic-rosbridge-server \
-    # new: vision & message transport
-    ros-noetic-usb-cam ros-noetic-cv-bridge ros-noetic-image-transport \
-    ros-noetic-sensor-msgs ros-noetic-std-msgs \
-    # misc tooling
-    python3-pip python3-pyqt5 alsa-utils \
-    portaudio19-dev \
-    build-essential \
-    git \
-    python3-rosdep \
-    python3-catkin-tools \
-    python3-matplotlib \
-    python3-numpy \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
+        ros-noetic-desktop \
+        ros-noetic-moveit \
+        ros-noetic-sound-play \
+        ros-noetic-dynamixel-sdk ros-noetic-dynamixel-sdk-examples \
+        ros-noetic-controller-manager ros-noetic-joint-state-controller \
+        ros-noetic-joint-state-publisher ros-noetic-robot-state-publisher \
+        ros-noetic-gazebo-ros-pkgs ros-noetic-gazebo-ros-control \
+        ros-noetic-ros-control ros-noetic-ros-controllers \
+        ros-noetic-rosbag \
+        ros-noetic-smach ros-noetic-smach-ros ros-noetic-smach-viewer \
+        ros-noetic-rosbridge-server \
+        # --- Vision ---
+        ros-noetic-usb-cam ros-noetic-cv-bridge ros-noetic-image-transport \
+        ros-noetic-sensor-msgs ros-noetic-std-msgs \
+        # --- Utilities ---
+        python3-pip python3-pyqt5 alsa-utils portaudio19-dev \
+        build-essential git python3-rosdep python3-catkin-tools \
+        python3-matplotlib python3-numpy tmux x11-apps htop \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-
- RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-    python-is-python3 \
-    tmux \
-    x11-apps \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-####################  Orbbec Astra SDK & driver  ####################
-# 1) System-level deps for OpenNI2 + libuvc
-# ── prerequisites ───────────────────────────────────────────────
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libusb-1.0-0-dev libudev-dev libglfw3-dev libopencv-dev \
-        libopenni2-dev openni2-utils unzip curl git wget bzip2 ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ros-noetic-backward-ros \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV OPENNI2_REDIST=/usr/lib   
-# ← add once, use everywhere
-
-# ── Orbbec OpenNI 2.3.0.86 (beta-6) install ─────────────────────
-# ──   Download once – cached ────────────────────────────────────────────
-RUN curl -L -o /tmp/openni.zip \
-        https://dl.orbbec3d.com/dist/openni2/v2.3.0.86-beta6/Orbbec_OpenNI_v2.3.0.86-beta6_linux_release.zip && \
-    mkdir -p /tmp/openni && \
-    unzip -q /tmp/openni.zip -d /tmp/openni
-
-# ──  Install & clean – reruns on changes only to this stanza ───────────
-RUN set -e && \
-    cd "$(find /tmp/openni -maxdepth 1 -type d -name 'OpenNI-Linux-x64*' | head -n1)" && \
-    ./install.sh && \
-    cp -f /usr/etc/udev/rules.d/*astra.rules /etc/udev/rules.d/ || true
-
-# 4) Pull the ROS driver into your workspace and build it
-RUN git clone --depth 1 https://github.com/orbbec/ros_astra_camera.git /catkin_ws/src/ros_astra_camera
-#    (driver supports Noetic – see repo’s README) :contentReference[oaicite:0]{index=0}
-
-# 5) Re-build workspace (adds astra_camera)
-# RUN /bin/bash -c "source /opt/ros/noetic/setup.bash && \
-#                   cd /catkin_ws && \
-#                   catkin_make -DCMAKE_BUILD_TYPE=Release"
-
-#####################################################################
-
-
-# ------------  Python user-level deps -----
+# ---------- Python packages ----------
 RUN pip3 install --default-timeout=100 \
-    numpy \
-    scipy \
-    matplotlib \
-    boto3 \
-    pyaudio \
-    opencv-python \
-    absl-py
+        numpy scipy matplotlib boto3 pyaudio opencv-python absl-py && \
+    pip3 install --no-deps mediapipe==0.10.11 opencv-contrib-python
 
-RUN pip3 install --no-deps mediapipe==0.10.11 opencv-contrib-python
-
-# ------------  Additional ROS packages -----
- RUN apt-get update && apt-get upgrade -y && \
+# ---------- Extra ROS packages ----------
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    ros-noetic-image-geometry \
-    ros-noetic-rgbd-launch libuvc-dev \
-    udev \
-    ros-noetic-rosserial-arduino \
-    ros-noetic-rosserial-client \
-    ros-noetic-rosserial-server \
-    ros-noetic-rosserial-python \
-    ros-noetic-rosserial-msgs \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
+        ros-noetic-image-geometry \
+        ros-noetic-rgbd-launch \  # keeps rgbd for completeness; safe to drop if un-needed
+        udev \
+        ros-noetic-rosserial-arduino ros-noetic-rosserial-client \
+        ros-noetic-rosserial-server ros-noetic-rosserial-python \
+        ros-noetic-rosserial-msgs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# ------------  AWS CLI  ------------
+# ---------- AWS CLI ----------
 RUN pip3 install awscli
 RUN mkdir -p /root/.aws
-COPY certs/aws-credentials  /root/.aws/credentials
+COPY certs/aws-credentials /root/.aws/credentials
 COPY certs/aws-config       /root/.aws/config
 RUN chmod 600 /root/.aws/*
-# (Optional) declare the default region once so every boto3 call has it
-ENV AWS_DEFAULT_REGION=us-east-1
+ENV AWS_DEFAULT_REGION=us-east-1     # optional convenience
 
-# ------------  Catkin workspace ----------
+# ---------- Catkin workspace ----------
 ENV CATKIN_WS=/catkin_ws
 RUN mkdir -p $CATKIN_WS/src
 WORKDIR $CATKIN_WS
+COPY . $CATKIN_WS/src/
 
-# Copy your code (instead of git-cloning inside the container)
-#    Context path must include this Dockerfile and your repo
-COPY . /$CATKIN_WS/src/ 
-
-# copy the startup script
-COPY ros_docker_auto_startup_launcher.sh /usr/local/bin/ros_docker_auto_startup_launcher.sh
+# ---------- Startup script ----------
+COPY ros_docker_auto_startup_launcher.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/ros_docker_auto_startup_launcher.sh
 
-# ------------  Audio & camera support -----------
- RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-    ros-noetic-audio-common \
-    python3-protobuf \
-    python3-tk \
-    htop \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-
-# resolve rosdep and build
-RUN rosdep init 
-
-RUN . /opt/ros/noetic/setup.sh && \
+# ---------- Build workspace ----------
+RUN rosdep init && \
+    . /opt/ros/noetic/setup.sh && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y && \
     catkin build -DCMAKE_BUILD_TYPE=Release
 
-# ------------  source overlays -----------
+# ---------- Convenience sources ----------
 RUN echo "source /opt/ros/noetic/setup.bash"   >> /etc/bash.bashrc && \
     echo "source /catkin_ws/devel/setup.bash" >> /etc/bash.bashrc
 
-# CMD ["bash"]
-
-# set the default entrypoint (or you can use CMD instead)
 ENTRYPOINT ["/usr/local/bin/ros_docker_auto_startup_launcher.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml
 services:
   flo_robot:
     build:
@@ -6,42 +5,29 @@ services:
       dockerfile: Dockerfile
     image: flo_system_v2_game_demo:latest
     container_name: flo_game
-    privileged: true          # required for USB devices and camera access
-    # network_mode: host               # ROS networking on host
+    privileged: true              # required for /dev/video0 & audio
     environment:
-      - DISPLAY=${DISPLAY}           # forward X11
+      - DISPLAY=${DISPLAY}
       - XAUTHORITY=/home/${USER}/.Xauthority
       - QT_X11_NO_MITSHM=1
       - LIBGL_ALWAYS_INDIRECT=0
-      - UDEV=1
-      - OPENNI2_REDIST=/usr/lib           # lets OpenNI find its .so at runtime
+      - UDEV=1                    # still useful for hot-plugged devices
     volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix:ro # GUI access
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
       - ${XAUTHORITY}:/home/${USER}/.Xauthority:ro
-      - /dev:/dev                     # for camera & devices
       - ./certs/aws-credentials:/root/.aws/credentials:ro
       - ./certs/aws-config:/root/.aws/config:ro
-      # - ${HOME}/.aws:/root/.aws:ro
-      - /lib/udev:/lib/udev:ro         # udev rules
-      - /etc/udev/rules.d:/etc/udev/rules.d  # your udev rules, if needed
-      - /dev/bus/usb:/dev/bus/usb     # pass through USB bus for Astra camera
-      - /run/udev:/run/udev
-      - /dev/snd:/dev/snd             # for audio devices
-      - /dev/ttyACM0:/dev/ttyACM0     # for serial devices (e.g., Arduino)
+      - /dev/video0:/dev/video0           # pass webcam
+      - /dev/snd:/dev/snd                 # pass audio
     devices:
-      - /dev/snd:/dev/snd             # for audio devices
-      - /dev/ttyACM0:/dev/ttyACM0     # for serial devices (e.g., Arduino)
-      - /dev/bus/usb:/dev/bus/usb
-      - /dev/video0:/dev/video0 # uncomment if you want to use a specific video device
+      - /dev/video0:/dev/video0           # explicit webcam access
+      - /dev/snd:/dev/snd                 # ALSA devices
+      - /dev/ttyACM0:/dev/ttyACM0         # keep serial (Arduino, etc.)
     working_dir: /catkin_ws
-    # command: >
-    #   bash -lc "
-    #     source /opt/ros/noetic/setup.bash 
-    #     && source /catkin_ws/devel/setup.bash
-    #     # Add commands to launch your ROS nodes or applications here
-    #     # && ...
-    #   "
     ipc: host
     tty: true
     stdin_open: true
-    entrypoint: [ "bash", "-c", "/usr/local/bin/ros_docker_auto_startup_launcher.sh && exec tail -f /dev/null" ]
+    entrypoint:
+      - bash
+      - -c
+      - "/usr/local/bin/ros_docker_auto_startup_launcher.sh && exec tail -f /dev/null"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - /dev/snd:/dev/snd             # for audio devices
       - /dev/ttyACM0:/dev/ttyACM0     # for serial devices (e.g., Arduino)
       - /dev/bus/usb:/dev/bus/usb
-      # - /dev/video0:/dev/video0 # uncomment if you want to use a specific video device
+      - /dev/video0:/dev/video0 # uncomment if you want to use a specific video device
     working_dir: /catkin_ws
     # command: >
     #   bash -lc "

--- a/ros_docker_auto_startup_launcher.sh
+++ b/ros_docker_auto_startup_launcher.sh
@@ -18,9 +18,9 @@ sleep 5
 # 2) In new tmux windows, launch your files
 tmux new-window -t ros:1 -n robot_sim 'roslaunch flo_core full_robot_arm_sim.launch' #launch the robot simulation
 sleep 15
-tmux new-window -t ros:2 -n camera 'roslaunch astra_camera astra.launch' # uncomment and complete with camera launch file
+tmux new-window -t ros:2 -n camera 'roslaunch flo_vision usb_cam_launcher.launch' #'roslaunch astra_camera astra.launch' # uncomment and complete with camera launch file
 sleep 2
-tmux new-window -t ros:3 -n vision 'rosrun flo_vision arm_hand_tracker_node.py _image:=/camera/color/image_raw _preview:=true _pose:=static' #uncomment to run the arm hand tracker node
+tmux new-window -t ros:3 -n vision 'rosrun flo_vision arm_hand_tracker_node.py _image:=usb_cam/image_raw  _preview:=true _pose:=static' #uncomment to run the arm hand tracker node
 sleep 2
 tmux new-window -t ros:4 -n vision_monitor 'rostopic echo /arm_hand_tracker/pose_score' #uncomment to monitor the arm hand tracker node
 sleep 5


### PR DESCRIPTION
Update the Docker configuration to enable the use of a Logi webcam instead of the Astra camera. Adjustments include modifications to the Dockerfile, docker-compose.yml, and startup script to ensure proper camera and audio device access. Additionally, clean up and optimize the installation of required packages.